### PR TITLE
Add picture of Aurora Australis from NASA

### DIFF
--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -1,6 +1,7 @@
 backgrounds = [
     'temp.jpg',
     'temp2.png',
+    'aurora-australis.jpg',
 ]
 
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -17,4 +17,12 @@
     <scolor>#000000</scolor>
     <shade_type>solid</shade_type>
   </wallpaper>
+  <wallpaper deleted="false">
+    <name>Aurora Australis</name>
+    <filename>@prefix@/share/backgrounds/budgie/aurora-australis.jpg</filename>
+    <options>zoom</options>
+    <pcolor>#000000</pcolor>
+    <scolor>#000000</scolor>
+    <shade_type>solid</shade_type>
+  </wallpaper>
 </wallpapers>


### PR DESCRIPTION
## Description

Aurora Australis as viewed by the International Space Station from NASA

### Image Information

- Author: NASA/JSC
- License: Public Domain
- Source: [Webpage](https://images.nasa.gov/details-iss029e008433), [Original image](https://images-assets.nasa.gov/image/iss029e008433/iss029e008433~orig.jpg)

Source image has been cropped to 4,256 × 2,394 size.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
