### PR TITLE
Add picture of the Caribbean islands from NASA

### DIFF
--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -2,6 +2,7 @@ backgrounds = [
     'apollo-11-earth.jpg',
     'aurora-australis.jpg',
     'lake-sherburne.jpg',
+    'caribbean-islands.jpg',
 ]
 
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -25,4 +25,12 @@
     <scolor>#000000</scolor>
     <shade_type>solid</shade_type>
   </wallpaper>
+  <wallpaper deleted="false">
+    <name>Caribbean Islands</name>
+    <filename>@prefix@/share/backgrounds/budgie/caribbean-islands.jpg</filename>
+    <options>zoom</options>
+    <pcolor>#000000</pcolor>
+    <scolor>#000000</scolor>
+    <shade_type>solid</shade_type>
+  </wallpaper>
 </wallpapers>


### PR DESCRIPTION
## Description

Picture from the ISS of the islands in the Caribbean Sea and southern Florida from NASA

### Image Information

- Author: NASA/JSC
- License: Public Domain
- Source: [Webpage](https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=ISS062&roll=E&frame=117852), [Original image](https://eol.jsc.nasa.gov/DatabaseImages/ESC/large/ISS062/ISS062-E-117852.JPG)

Source image has been cropped to 5,568 × 3,132.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
