### PR TITLE
Add picture of Lesser Antilles from NASA

### DIFF
--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -2,6 +2,7 @@ backgrounds = [
     'apollo-11-earth.jpg',
     'aurora-australis.jpg',
     'lake-sherburne.jpg',
+    'lesser-antilles.jpg',
 ]
 
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -25,4 +25,12 @@
     <scolor>#000000</scolor>
     <shade_type>solid</shade_type>
   </wallpaper>
+  <wallpaper deleted="false">
+    <name>Lesser Antilles</name>
+    <filename>@prefix@/share/backgrounds/budgie/lesser-antilles.jpg</filename>
+    <options>zoom</options>
+    <pcolor>#000000</pcolor>
+    <scolor>#000000</scolor>
+    <shade_type>solid</shade_type>
+  </wallpaper>
 </wallpapers>


### PR DESCRIPTION
## Description

Picture taken from the International Space Station of the Lesser Antilles islands in the Caribbean from NASA

### Image Information

- Author: NASA/JSC
- License: Public Domain
- Source: [Webpage](https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=ISS030&roll=E&frame=59560), [Original image](https://eol.jsc.nasa.gov/DatabaseImages/ESC/large/ISS030/ISS030-E-59560.JPG)

Source image was cropped to the size of 3,840 × 2,160.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
