### PR TITLE
Avoid to install bash for build stage

### DIFF
--- a/scripts/optimizeImage.sh
+++ b/scripts/optimizeImage.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 INPUT="$1"
 OUTPUT="$2"
@@ -8,9 +8,9 @@ cp "$INPUT" "$OUTPUT" || exit 1
 mogrify -format jpg "$OUTPUT" || exit 2
 mogrify -resize 3840x2160^ "$OUTPUT" || exit 3
 
-QUALITY="$(identify -verbose $OUTPUT | grep 'Image:\|Quality')"
+QUALITY=$(identify -format %Q  $OUTPUT) 
 
-if [[ "$QUALITY" > 90 ]]; then
+if [ $QUALITY -gt 90 ]; then
     mogrify -quality 90 "$OUTPUT" || exit 4
 fi
 


### PR DESCRIPTION
This patch avoids to install bash for build stage (especially for BSD systems where it is not installed by default).

Tested on FreeBSD (where I use Budgie).