### PR TITLE
Add picture of Noche Bogota from Flickr

### DIFF
--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -20,6 +20,7 @@ backgrounds = [
     'waves-midnight.jpg',
     'waves-slate.jpg',
     'blue-periwinkle.jpg',
+    'noche-bogota.jpg',
 ]
 
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -178,4 +178,12 @@
     <scolor>#000000</scolor>
     <shade_type>solid</shade_type>
   </wallpaper>
+  <wallpaper deleted="false">
+    <name>Noche Bogota</name>
+    <filename>@prefix@/share/backgrounds/budgie/noche-bogota.jpg</filename>
+    <options>zoom</options>
+    <pcolor>#000000</pcolor>
+    <scolor>#000000</scolor>
+    <shade_type>solid</shade_type>
+  </wallpaper>
 </wallpapers>


### PR DESCRIPTION
## Description

Long-exposure photo of Bogota at night

### Image Information

- Author: Andres Cadena
- License: CC0
- Source: [Webpage](https://www.flickr.com/photos/140325887@N04/25537411757/)

Image has been downscaled from its original size to `3,840 × 2,560`.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
