### PR TITLE
Add picture of Island Hopping from Wikimedia Commons

### DIFF
--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -27,6 +27,7 @@ backgrounds = [
     'ocean-waves.jpg',
     'motherboard-circuits.jpg',
     'singaporean-cityscape.jpg',
+    'island-hopping.jpg',
 ]
 
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -233,4 +233,12 @@
     <scolor>#000000</scolor>
     <shade_type>solid</shade_type>
   </wallpaper>
+  <wallpaper deleted="false">
+    <name>Island hopping</name>
+    <filename>@prefix@/share/backgrounds/budgie/island-hopping.jpg</filename>
+    <options>zoom</options>
+    <pcolor>#000000</pcolor>
+    <scolor>#000000</scolor>
+    <shade_type>solid</shade_type>
+  </wallpaper>
 </wallpapers>


### PR DESCRIPTION
## Description

A view from the top of Pescador Island with island-hopping boats nearby

### Image Information

- Author: Ken Suarez
- License: CC0
- Source: [Webpage](https://commons.wikimedia.org/wiki/File:A_view_from_the_top_of_Pescador_Island_(Unsplash).jpg), [Original](https://upload.wikimedia.org/wikipedia/commons/2/27/A_view_from_the_top_of_Pescador_Island_%28Unsplash%29.jpg)

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
