### PR TITLE
Convert images to JXL, add submission format policy, drop jhead dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,7 @@ jobs:
             gcc \
             git \
             meson \
-            ImageMagick \
-            jhead
+            ImageMagick
       - uses: actions/checkout@v3
       - name: Build Budgie Backgrounds
         run: |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Below is a list of requirements that submissions must satisfy before they are re
 
 - Must be licensed under CC0 or Public Domain. Specify which license the artwork is under.
 - Image must be 3840x2160 or higher.
+- Image must be in the JPEG format; other formats may be considered in the future.
 - If you are not the original author, you must provide the source: URL to the webpage hosting the image, direct download (if possible) to the image, name of author.
 - No brand names, trademarks, or logos.
 - No branding assets should be used as it should be assumed these works will be used across many installations of Budgie Desktop, regardless of the operating system.

--- a/backgrounds/meson.build
+++ b/backgrounds/meson.build
@@ -23,7 +23,6 @@ backgrounds = [
 backgrounds_dir = join_paths(path_datadir, 'backgrounds', 'budgie')
 
 mogrify = find_program('mogrify')
-jhead = find_program('jhead')
 
 script = find_program(join_paths(meson.source_root(), 'scripts', 'optimizeImage.sh'))
 
@@ -31,7 +30,7 @@ optimized_background_targets = []
 foreach background : backgrounds
     optimized_background_targets += custom_target(background,
         input: background,
-        output: '@BASENAME@.jpg',
+        output: '@BASENAME@.jxl',
         command: [script, '@INPUT@', '@OUTPUT@'],
         install: true,
         install_dir: backgrounds_dir

--- a/data/budgie-backgrounds.xml.in
+++ b/data/budgie-backgrounds.xml.in
@@ -3,7 +3,7 @@
 <wallpapers>
   <wallpaper deleted="false">
     <name>Lake Sherburne</name>
-    <filename>@prefix@/share/backgrounds/budgie/lake-sherburne.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/lake-sherburne.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -11,7 +11,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Amidst the Tea Gardens</name>
-    <filename>@prefix@/share/backgrounds/budgie/tea-gardens.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/tea-gardens.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -19,7 +19,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Perched Osprey</name>
-    <filename>@prefix@/share/backgrounds/budgie/perched-osprey.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/perched-osprey.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -27,7 +27,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Canyon Wren</name>
-    <filename>@prefix@/share/backgrounds/budgie/canyon-wren.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/canyon-wren.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -35,7 +35,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Oakland Zoo Otters</name>
-    <filename>@prefix@/share/backgrounds/budgie/oakland-zoo-otters.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/oakland-zoo-otters.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -43,7 +43,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Beacon Street Sunset</name>
-    <filename>@prefix@/share/backgrounds/budgie/beacon-street-sunset.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/beacon-street-sunset.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -51,7 +51,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Roman Colosseum</name>
-    <filename>@prefix@/share/backgrounds/budgie/roman-colosseum.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/roman-colosseum.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -59,7 +59,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Piazza Gae Aulenti</name>
-    <filename>@prefix@/share/backgrounds/budgie/piazza-gae-aulenti.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/piazza-gae-aulenti.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -67,7 +67,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>High Trestle Trail</name>
-    <filename>@prefix@/share/backgrounds/budgie/high-trestle-trail.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/high-trestle-trail.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -75,7 +75,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Saturnian Profile</name>
-    <filename>@prefix@/share/backgrounds/budgie/saturnian-profile.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/saturnian-profile.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -83,7 +83,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Abstract Spiral</name>
-    <filename>@prefix@/share/backgrounds/budgie/abstract-spiral.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/abstract-spiral.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -91,7 +91,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Valley Midnight</name>
-    <filename>@prefix@/share/backgrounds/budgie/valley-midnight.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/valley-midnight.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -99,7 +99,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Waves Midnight</name>
-    <filename>@prefix@/share/backgrounds/budgie/waves-midnight.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/waves-midnight.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -107,7 +107,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Blue Periwinkle</name>
-    <filename>@prefix@/share/backgrounds/budgie/blue-periwinkle.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/blue-periwinkle.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -115,7 +115,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Extreme Desert Hike</name>
-    <filename>@prefix@/share/backgrounds/budgie/extreme-desert-hike.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/extreme-desert-hike.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -123,7 +123,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Casa Mila</name>
-    <filename>@prefix@/share/backgrounds/budgie/casa-mila.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/casa-mila.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -131,7 +131,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Ocean Waves</name>
-    <filename>@prefix@/share/backgrounds/budgie/ocean-waves.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/ocean-waves.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -139,7 +139,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>Singaporean Cityscape</name>
-    <filename>@prefix@/share/backgrounds/budgie/singaporean-cityscape.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/singaporean-cityscape.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>
@@ -147,7 +147,7 @@
   </wallpaper>
   <wallpaper deleted="false">
     <name>The Spices of Life</name>
-    <filename>@prefix@/share/backgrounds/budgie/the-spices-of-life.jpg</filename>
+    <filename>@prefix@/share/backgrounds/budgie/the-spices-of-life.jxl</filename>
     <options>zoom</options>
     <pcolor>#000000</pcolor>
     <scolor>#000000</scolor>

--- a/scripts/optimizeImage.sh
+++ b/scripts/optimizeImage.sh
@@ -5,7 +5,7 @@ OUTPUT="$2"
 
 cp "$INPUT" "$OUTPUT" || exit 1
 
-mogrify -format jpg "$OUTPUT" || exit 2
+mogrify -format jxl -strip "$OUTPUT" || exit 2
 mogrify -resize 3840x2160^ "$OUTPUT" || exit 3
 
 QUALITY=$(identify -format %Q  $OUTPUT) 
@@ -13,5 +13,3 @@ QUALITY=$(identify -format %Q  $OUTPUT)
 if [ $QUALITY -gt 90 ]; then
     mogrify -quality 90 "$OUTPUT" || exit 4
 fi
-
-jhead -autorot -de -di -du -c "$OUTPUT" || exit 5


### PR DESCRIPTION
## Description
Changes output format to JXL, formalises submission format policy, and removes unneeded `jhead` dependency.

Replaces https://github.com/BuddiesOfBudgie/budgie-backgrounds/pull/58.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
